### PR TITLE
perf(dependencies): shrink dependency footprint

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/kenny-hibino/redux-camel#readme",
   "dependencies": {
-    "lodash": "4.17.4"
+    "lodash.camelcase": "4.3.0"
   },
   "devDependencies": {
     "babel-cli": "6.24.1",

--- a/src/camelcaseKeys.js
+++ b/src/camelcaseKeys.js
@@ -1,13 +1,13 @@
-import _ from 'lodash';
+import camelCase from 'lodash.camelcase';
 
 const camelcaseKeys = (obj) => {
-  let newObject = _.isArray(obj) ? [] : {};
+  let newObject = Array.isArray(obj) ? [] : {};
 
   for (let prop in obj) {
     if (typeof obj[prop] === 'object' && obj[prop] !== null) {
-      newObject[_.camelCase(prop)] = camelcaseKeys(obj[prop]);
+      newObject[camelCase(prop)] = camelcaseKeys(obj[prop]);
     } else {
-      newObject[_.camelCase(prop)] = obj[prop];
+      newObject[camelCase(prop)] = obj[prop];
     }
   }
   return newObject;


### PR DESCRIPTION
use `lodash.camelcase` and `Array.isArray` instead of _all_ of lodash

fixes #2