### PR TITLE
Enable support for Redux Toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ applyMiddleware(camelMiddleware({ global: false }));
 
 // Then you can dispatch an action with camelCase set to true
 dispatch({ type: 'FETCH_POSTS_SUCCESS', payload: posts, camelCase: true });
+
+/* Example #3 (Redux Toolkit) */
+// Omit global option
+const store = configureStore({
+  ...
+  middleware: [camelMiddleware({ global: false }), ...getDefaultMiddleware()],
+})
+
+// Then add to the arg object with camelCase set to true
+search({ query: 'some query', camelCase: true });
 ```
 
 ## License

--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,14 @@ import camelcaseKeys from './camelcaseKeys';
 
 const defaultOptions = { global: true };
 
+const checkCamelCaseKey = (action) => {
+  if (typeof action === 'object') {
+    return !!action.camelCase || !!action.meta.arg.camelCase
+  }
+}
+
 const camelMiddleware = (options = defaultOptions) => store => next => action => {
-  const shouldCamelCaseKeys = options.global || !!action.camelCase;
+  const shouldCamelCaseKeys = options.global || checkCamelCaseKey(action);
   if (typeof action === 'object' && shouldCamelCaseKeys) {
     const newAction = camelcaseKeys(action);
     return next(newAction);


### PR DESCRIPTION
This PR enables support for [Redux Tookit](https://redux-toolkit.js.org/). RTK is a little different in that the resulting action has any args attached to the `action.meta` property (ref: https://redux-toolkit.js.org/api/createAsyncThunk#promise-lifecycle-actions) instead of alongside payload/type in the root object. An example looks like this:

<img width="274" alt="Screen Shot 2020-07-13 at 4 17 02 PM" src="https://user-images.githubusercontent.com/17421347/87276746-5132ce00-c524-11ea-869e-fab3a8e6eea1.png">
